### PR TITLE
Add support for startup python file parsing through --startupFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.29 October 24, 2020
+
+Added support for passing a python file to be parsed at startup through the
+`--startupFile` flag. (by @nfraprado)
+
 # 1.0.28 June 23, 2019
 
 Added `packages` to `setup.py`, maybe thereby fixing

--- a/README.md
+++ b/README.md
@@ -664,7 +664,6 @@ saved to `~/.pycalc_history` if your version of readline has the
 ## Todo
 
 * Add direct access to functionality from [numpy](https://www.numpy.org/).
-* Read start-up file of user-defined functions.
 * Add rotate-right and rotate-left stack modifying functions?
 
 ## Thanks

--- a/rpn.py
+++ b/rpn.py
@@ -103,6 +103,11 @@ def parseArgs():
               'the calculator, you can use this option to also read commands '
               'from standard input once the command line has been executed.'))
 
+    parser.add_argument(
+        '--startupFile',
+        help=('Python file to be parsed at startup. Usually used to define '
+              'custom functions'))
+
     return parser.parse_args()
 
 
@@ -115,6 +120,13 @@ if __name__ == '__main__':
     else:
         calc = Calculator(autoPrint=args.print, splitLines=args.splitLines,
                           separator=args.separator, debug=args.debug)
+
+        if args.startupFile:
+            try:
+                with open(args.startupFile) as f:
+                    exec(f.read(), globals(), calc._variables)
+            except FileNotFoundError:
+                calc.err('Startup file %s not found' % args.startupFile)
 
         interactive = setupReadline()
 

--- a/rpnpy/__init__.py
+++ b/rpnpy/__init__.py
@@ -9,7 +9,7 @@ if sys.version_info < (3,):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '1.0.28'
+__version__ = '1.0.29'
 
 # Keep Python linters quiet.
 _ = Calculator


### PR DESCRIPTION
Add `--startupFile` flag to specify a python file to be parsed at startup. The functions defined here are available in the REPL.
Import statements should be done inside the functions that use them in order for it to work.

Also remove this from the TODO list in the README.

Fixes #2 .