### PR TITLE
Add support for engineering notation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,2 @@
+Terry Jones (@terrycojones)
+Nícolas F. R. A. Prado (@nfraprado)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.30 October 26, 2020
+
+Added support for engineering notation for numbers by using the
+`engineering_notation` python package. It is now a dependency of `rpnpy`. (by
+@nfraprado)
+
 # 1.0.29 October 24, 2020
 
 Added support for passing a python file to be parsed at startup through the

--- a/README.md
+++ b/README.md
@@ -408,6 +408,31 @@ Leading and trailing whitespace in the command is ignored. Whitespace
 anywhere in the modifiers is ignored (unless line splitting is on, in which
 case you will get errors).
 
+#### Engineering notation
+
+Numbers can be inputted using engineering notation:
+
+```
+$ rpn.py
+--> 20k 1.5M +
+1.52M
+```
+
+Values on the stack will only be displayed using engineering notation if they
+were inputted so:
+
+```
+$ rpn.py
+--> 2000
+--> f
+--> [2000]
+--> 2k
+--> f
+--> [2000, 2k]
+--> +
+--> [4k]
+```
+
 ## Operation via standard input
 
 When reading from standard input, the lines will be split on whitespace and

--- a/rpnpy/__init__.py
+++ b/rpnpy/__init__.py
@@ -9,7 +9,7 @@ if sys.version_info < (3,):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '1.0.29'
+__version__ = '1.0.30'
 
 # Keep Python linters quiet.
 _ = Calculator

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ setup(name='rpnpy',
       license='MIT',
       scripts=['rpn.py'],
       description=('Control an RPN calculator from Python.'),
+      install_requires=[
+          'engineering_notation'
+      ],
       extras_require={
         'dev': [
             'flake8',


### PR DESCRIPTION
This enables the user to input numbers in engineering notation like `2k` for `2000`, or `3.3m` for `0.0033`. The value is saved as a `EngNumber` instance, so it also prints in engineering notation from the stack.
This is done by using https://github.com/slightlynybbled/engineering_notation , so this python package needs to be installed, as well as a `--engineeringNotation` flag needs to be passed for the engineering notation to work.

@terrycojones is this something you think should be part of rpnpy? If so, I can also add a little section in the README describing this feature and the dependency.
Also, the big change in the diff is actually an indentation change.