### PR TITLE
Make variables command only show user-defined variables 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.0 December 3, 2020
+
+Changed default behaviour of the `:r` modifier following discussion with
+@nfraprado at https://github.com/terrycojones/rpnpy/issues/6.
+
+*Note that this is a backwards-incompatible change!*
+
 # 1.0.31 December 2, 2020
 
 Added special `store` command to save stack values into a variable,

--- a/README.md
+++ b/README.md
@@ -511,7 +511,8 @@ There are two kinds of commands: special and normal.
 * `swap`: Swap the top two stack elements (this is the same as calling
     `reverse` with no arguments.
 * `undo`: Undo the last stack-changing operation and variable settings.
-* `variables`: Show all known variables and their values.
+* `variables`: Show all user-defined variables and their values.
+* `variables_all`: Show **all** known variables and their values.
 
 ### Normal
 

--- a/rpnpy/__init__.py
+++ b/rpnpy/__init__.py
@@ -9,7 +9,7 @@ if sys.version_info < (3,):
 # will not be found by the version() function in ../setup.py
 #
 # Remember to update ../CHANGELOG.md describing what's new in each version.
-__version__ = '1.0.31'
+__version__ = '2.0.0'
 
 # Keep Python linters quiet.
 _ = Calculator

--- a/rpnpy/calculator.py
+++ b/rpnpy/calculator.py
@@ -77,6 +77,7 @@ class Calculator:
         self._functions = {}
         self._special = {}
         self._variables = {}
+        self._userVariables = []
 
         self.addSpecialCases()
         addSpecialFunctions(self)
@@ -546,6 +547,7 @@ class Calculator:
                 value = EngNumber(command)
             except decimal.InvalidOperation:
                 try:
+                    variables_before = set(self._variables.keys())
                     exec(command, globals(), self._variables)
                 except BaseException as e:
                     err = str(e)
@@ -561,6 +563,13 @@ class Calculator:
                                       'whitespace in a command line?')
                     raise CalculatorError(*errors)
                 else:
+                    # If we have new variables, add them to the user variables
+                    # list
+                    variables_after = set(self._variables.keys())
+                    new_variables = variables_after.difference(variables_before)
+                    for var in new_variables:
+                        self._userVariables.append(var)
+
                     self.debug('exec(%r) worked.' % command)
                     return True, self.NO_VALUE
             else:
@@ -738,11 +747,12 @@ class Calculator:
         return self._findWithArgs(command, 'a string', predicate,
                                   defaultArgCount, modifiers, count)
 
-    def setVariable(self, variable, value):
+    def setUserVariable(self, variable, value):
         """
-        Set the value of a variable.
+        Set the value of a user-defined variable.
 
         @param variable: The C{str} variable name.
         @param value: The value to give the variable.
         """
         self._variables[variable] = value
+        self._userVariables.append(variable)

--- a/rpnpy/calculator.py
+++ b/rpnpy/calculator.py
@@ -661,26 +661,6 @@ class Calculator:
                              (command, stackLen, '' if stackLen == 1 else 's'))
 
         if modifiers.reverse:
-            item = self.stack[-1]
-
-            if not predicate(item):
-                raise StackError('Top stack item (%r) is not %s' %
-                                 (item, description))
-
-            if count is None:
-                count = (stackLen - 1 if modifiers.all else
-                         defaultArgCount(item))
-
-            nargsAvail = stackLen - 1
-            if nargsAvail < count:
-                raise StackError(
-                    'Cannot run %r with %d argument%s '
-                    '(stack has only %d item%s available)' %
-                    (command, count, '' if count == 1 else 's',
-                     nargsAvail, '' if nargsAvail == 1 else 's'))
-
-            args = self.stack[-(count + 1):-1]
-        else:
             if count is None:
                 if modifiers.all:
                     item = self.stack[0]
@@ -708,6 +688,26 @@ class Calculator:
                                     item, description))
 
                 args = self.stack[-count:]
+        else:
+            item = self.stack[-1]
+
+            if not predicate(item):
+                raise StackError('Top stack item (%r) is not %s' %
+                                 (item, description))
+
+            if count is None:
+                count = (stackLen - 1 if modifiers.all else
+                         defaultArgCount(item))
+
+            nargsAvail = stackLen - 1
+            if nargsAvail < count:
+                raise StackError(
+                    'Cannot run %r with %d argument%s '
+                    '(stack has only %d item%s available)' %
+                    (command, count, '' if count == 1 else 's',
+                     nargsAvail, '' if nargsAvail == 1 else 's'))
+
+            args = self.stack[-(count + 1):-1]
 
         return item, self.convertStackArgs(args)
 

--- a/rpnpy/functions.py
+++ b/rpnpy/functions.py
@@ -55,7 +55,7 @@ def stack(calc, modifiers, count):
 stack.names = ('stack', 's', 'f')
 
 
-def variables(calc, modifiers, count):
+def variables_all(calc, modifiers, count):
     """Show all variables.
 
     @param calc: A C{Calculator} instance.
@@ -67,8 +67,21 @@ def variables(calc, modifiers, count):
     return calc.NO_VALUE
 
 
-variables.names = ('variables',)
+variables_all.names = ('variables_all',)
 
+def variables_user(calc, modifiers, count):
+    """Show user-defined variables.
+
+    @param calc: A C{Calculator} instance.
+    @param modifiers: A C{Modifiers} instance.
+    @param count: An C{int} count of the number of arguments to pass.
+    """
+    for name, value in sorted(calc._variables.items()):
+        if name in calc._userVariables:
+            calc.report('%s: %r' % (name, value))
+    return calc.NO_VALUE
+
+variables_user.names = ('variables',)
 
 def clear(calc, modifiers, count):
     """
@@ -318,7 +331,7 @@ def store(calc, modifiers, count):
     else:
         value = args
 
-    calc.setVariable(variable, value)
+    calc.setUserVariable(variable, value)
     calc._finalize(None, nPop=len(args) + 1, modifiers=modifiers, noValue=True)
     return calc.NO_VALUE
 
@@ -369,7 +382,8 @@ FUNCTIONS = (
     store,
     swap,
     undo,
-    variables,
+    variables_all,
+    variables_user,
 )
 
 

--- a/rpnpy/functions.py
+++ b/rpnpy/functions.py
@@ -374,7 +374,7 @@ FUNCTIONS = (
 
 
 def addSpecialFunctions(calc):
-    """Add functions defined above
+    """Add functions defined above.
 
     @param calc: A C{Calculator} instance.
     """

--- a/test/test_calculator.py
+++ b/test/test_calculator.py
@@ -247,9 +247,9 @@ class TestCalculator(TestCase):
     def testItemgetter(self):
         "itemgetter must work correctly"
         c = Calculator(splitLines=False)
+        c.execute('[[1, 2, 3], [4, 5, 6]]')
         c.execute('1')
         c.execute('itemgetter')
-        c.execute('[[1, 2, 3], [4, 5, 6]]')
         c.execute('map :i')
         (result,) = c.stack
         self.assertEqual([2, 5], result)
@@ -265,7 +265,6 @@ class TestCalculator(TestCase):
         "Converting the top two items of the stack to a list must work"
         c = Calculator()
         c.execute('4 5 list:2')
-        c.printStack()
         (result,) = c.stack
         self.assertEqual([4, 5], result)
 
@@ -273,7 +272,6 @@ class TestCalculator(TestCase):
         "Converting all items of the stack to a list must work"
         c = Calculator()
         c.execute('4 5 6 list:*')
-        c.printStack()
         (result,) = c.stack
         self.assertEqual([4, 5, 6], result)
 
@@ -354,8 +352,8 @@ class TestReverseModifier(TestCase):
     def testMap(self):
         "Call map with args reversed from their normal order"
         c = Calculator()
-        c.execute('[1,2,3]')
         c.execute('str :!')
+        c.execute('[1,2,3]')
         c.execute('map :ir')
         (result,) = c.stack
         self.assertEqual(['1', '2', '3'], result)
@@ -426,68 +424,68 @@ class TestJoin(TestCase):
     def testEmptyString(self):
         "Joining on an empty string must work"
         c = Calculator()
-        c.execute('"" ["4","5","6"] join')
+        c.execute('["4","5","6"] "" join')
         (result,) = c.stack
         self.assertEqual('456', result)
 
     def testNonEmptyString(self):
         "Joining on a non-empty string must work"
         c = Calculator()
-        c.execute('"-" ["4","5","6"] join')
+        c.execute('["4","5","6"] "-" join')
         (result,) = c.stack
         self.assertEqual('4-5-6', result)
 
     def testNonStrings(self):
         "Joining things that are not string must work"
         c = Calculator()
-        c.execute('"-" [4,5,6] join')
+        c.execute('[4,5,6] "-" join')
         (result,) = c.stack
         self.assertEqual('4-5-6', result)
 
     def testWithCount(self):
         "Joining several stack items must work"
         c = Calculator()
-        c.execute('3 "-" 4 5 6 join:3')
+        c.execute('3 4 5 6 "-" join:3')
         self.assertEqual([3, '4-5-6'], c.stack)
 
     def testAllStack(self):
         "Joining the whole stack"
         c = Calculator()
-        c.execute('"-" 3 4 5 6 join:*')
+        c.execute('3 4 5 6 "-" join:*')
         (result,) = c.stack
         self.assertEqual('3-4-5-6', result)
 
     def testEmptyStringReversed(self):
         "Joining on an empty string must work"
         c = Calculator()
-        c.execute('["4","5","6"] "" join:r')
+        c.execute('"" ["4","5","6"] join:r')
         (result,) = c.stack
         self.assertEqual('456', result)
 
     def testNonEmptyStringReversed(self):
         "Joining on a non-empty string must work"
         c = Calculator()
-        c.execute('["4","5","6"] "-" join:r')
+        c.execute('"-" ["4","5","6"] join:r')
         (result,) = c.stack
         self.assertEqual('4-5-6', result)
 
     def testNonStringsReversed(self):
         "Joining things that are not string must work"
         c = Calculator()
-        c.execute('[4,5,6] "-" join:r')
+        c.execute('"-" [4,5,6] join:r')
         (result,) = c.stack
         self.assertEqual('4-5-6', result)
 
     def testWithCountReversed(self):
         "Joining several stack items must work"
         c = Calculator()
-        c.execute('3 4 5 6 "-" join:3r')
+        c.execute('3 "-" 4 5 6 join:3r')
         self.assertEqual([3, '4-5-6'], c.stack)
 
     def testAllStackReversed(self):
         "Joining the whole stack"
         c = Calculator()
-        c.execute('3 4 5 6 "-" join:*r')
+        c.execute('"-" 3 4 5 6 join:*r')
         (result,) = c.stack
         self.assertEqual('3-4-5-6', result)
 
@@ -508,7 +506,7 @@ class TestStore(TestCase):
     def testStackWithTwoItemsClearsStack(self):
         "Calling store on a stack with two items must result in an empty stack"
         c = Calculator()
-        c.execute('"a" 4 store')
+        c.execute('4 "a" store')
         self.assertEqual([], c.stack)
 
     def testStackWithTwoItemsPreservingStack(self):
@@ -526,7 +524,7 @@ class TestStore(TestCase):
         being set as expected.
         """
         c = Calculator()
-        c.execute('"a" 4 store a')
+        c.execute('4 "a" store a')
         (result,) = c.stack
         self.assertEqual(4, result)
 
@@ -536,7 +534,7 @@ class TestStore(TestCase):
         result in the variable being set as expected.
         """
         c = Calculator()
-        c.execute('"a" 4 5 store:2 a')
+        c.execute('4 5 "a" store:2 a')
         self.assertEqual([[4, 5]], c.stack)
 
     def testStackWithThreeItemsReversed(self):
@@ -545,7 +543,7 @@ class TestStore(TestCase):
         the reverse modifier must result in the variable being set as expected.
         """
         c = Calculator()
-        c.execute('4 5 "a" store:r2 a')
+        c.execute('"a" 4 5 store:r2 a')
         self.assertEqual([[4, 5]], c.stack)
 
     def testStarModifier(self):
@@ -554,7 +552,7 @@ class TestStore(TestCase):
         result in the variable being set as expected.
         """
         c = Calculator()
-        c.execute('"a" 4 5 6 store:* a')
+        c.execute('4 5 6 "a" store:* a')
         self.assertEqual([[4, 5, 6]], c.stack)
 
     def testStarModifierReversed(self):
@@ -563,7 +561,7 @@ class TestStore(TestCase):
         reverse modifier must result in the variable being set as expected.
         """
         c = Calculator()
-        c.execute('4 5 6 "a" store:r* a')
+        c.execute('"a" 4 5 6 store:r* a')
         self.assertEqual([[4, 5, 6]], c.stack)
 
 
@@ -592,8 +590,8 @@ class TestFindCallableAndArgs(TestCase):
         correctly. The number of stack items is obtained from the function
         signature"""
         c = Calculator()
-        c.execute('log10 :!')
         c.execute('4')
+        c.execute('log10 :!')
         func, args = c.findCallableAndArgs('cmd', Modifiers(), None)
         self.assertIs(math.log10, func)
         self.assertEqual([4], args)
@@ -602,31 +600,18 @@ class TestFindCallableAndArgs(TestCase):
         """Calling on a stack with two items and a count must return
         correctly."""
         c = Calculator()
-        c.execute('log10 :!')
         c.execute('4')
+        c.execute('log10 :!')
         func, args = c.findCallableAndArgs('cmd', Modifiers(), 1)
         self.assertIs(math.log10, func)
         self.assertEqual([4], args)
 
-    def testStackLengthThreeWithCountError(self):
-        """Calling on a stack with three items and a count that points to a
-        non-callable must result in an error"""
-        errfp = StringIO()
-        c = Calculator(errfp=errfp)
-        c.execute('log10 :!')
-        c.execute('4')
-        c.execute('5')
-        error = (r"^Cannot run 'cmd' with 1 argument. Stack item \(4\) is "
-                 r"not callable$")
-        self.assertRaisesRegex(StackError, error, c.findCallableAndArgs,
-                               'cmd', Modifiers(), 1)
-
     def testStackLengthThree(self):
         "Calling on a stack with three items (count=2) must return correctly"
         c = Calculator()
-        c.execute('log10 :!')
         c.execute('4')
         c.execute('5')
+        c.execute('log10 :!')
         func, args = c.findCallableAndArgs('cmd', Modifiers(), 2)
         self.assertIs(math.log10, func)
         self.assertEqual([4, 5], args)
@@ -634,10 +619,10 @@ class TestFindCallableAndArgs(TestCase):
     def testAllStack(self):
         "Calling on all the stack must return correctly"
         c = Calculator()
-        c.execute('log10 :!')
         c.execute('4')
         c.execute('5')
         c.execute('6')
+        c.execute('log10 :!')
         func, args = c.findCallableAndArgs('cmd', strToModifiers('*'), None)
         self.assertIs(math.log10, func)
         self.assertEqual([4, 5, 6], args)
@@ -666,8 +651,8 @@ class TestFindCallableAndArgsReversed(TestCase):
         correctly. The number of stack items is obtained from the function
         signature"""
         c = Calculator()
-        c.execute('4')
         c.execute('log10 :!')
+        c.execute('4')
         func, args = c.findCallableAndArgs('cmd', strToModifiers('r'), None)
         self.assertIs(math.log10, func)
         self.assertEqual([4], args)
@@ -676,8 +661,8 @@ class TestFindCallableAndArgsReversed(TestCase):
         """Calling on a stack with two items and a count must return
         correctly."""
         c = Calculator()
-        c.execute('4')
         c.execute('log10 :!')
+        c.execute('4')
         func, args = c.findCallableAndArgs('cmd', strToModifiers('r'), 1)
         self.assertIs(math.log10, func)
         self.assertEqual([4], args)
@@ -685,20 +670,33 @@ class TestFindCallableAndArgsReversed(TestCase):
     def testStackLengthThree(self):
         "Calling on a stack with three items (count=2) must return correctly"
         c = Calculator()
+        c.execute('log10 :!')
         c.execute('5')
         c.execute('4')
-        c.execute('log10 :!')
         func, args = c.findCallableAndArgs('cmd', strToModifiers('r'), 2)
         self.assertIs(math.log10, func)
         self.assertEqual([5, 4], args)
 
+    def testStackLengthThreeWithCountError(self):
+        """Calling on a stack with three items and a count that points to a
+        non-callable must result in an error"""
+        errfp = StringIO()
+        c = Calculator(errfp=errfp)
+        c.execute('log10 :!')
+        c.execute('4')
+        c.execute('5')
+        error = (r"^Cannot run 'cmd' with 1 argument. Stack item \(4\) is "
+                 r"not callable$")
+        self.assertRaisesRegex(StackError, error, c.findCallableAndArgs,
+                               'cmd', strToModifiers('r'), 1)
+
     def testAllStack(self):
         "Calling on all the stack must return correctly"
         c = Calculator()
+        c.execute('log10 :!')
         c.execute('4')
         c.execute('5')
         c.execute('6')
-        c.execute('log10 :!')
         func, args = c.findCallableAndArgs('cmd', strToModifiers('*r'), None)
         self.assertIs(math.log10, func)
         self.assertEqual([4, 5, 6], args)
@@ -727,8 +725,8 @@ class TestFindStringAndArgs(TestCase):
         correctly. The number of stack items is obtained from the function
         signature"""
         c = Calculator()
-        c.execute("'string'")
         c.execute('4')
+        c.execute("'string'")
         string, args = c.findStringAndArgs('cmd', Modifiers(), None)
         self.assertEqual('string', string)
         self.assertEqual([4], args)
@@ -737,30 +735,18 @@ class TestFindStringAndArgs(TestCase):
         """Calling on a stack with two items and a count must return
         correctly."""
         c = Calculator()
-        c.execute("'string'")
         c.execute('4')
+        c.execute("'string'")
         string, args = c.findStringAndArgs('cmd', Modifiers(), 1)
         self.assertEqual('string', string)
         self.assertEqual([4], args)
 
-    def testStackLengthThreeWithCountError(self):
-        """Calling on a stack with three items and a count that points to a
-        non-string must result in an error"""
-        c = Calculator()
-        c.execute("'string'")
-        c.execute('4')
-        c.execute('5')
-        error = (r"^Cannot run 'cmd' with 1 argument. Stack item \(4\) is "
-                 r"not a string$")
-        self.assertRaisesRegex(StackError, error, c.findStringAndArgs,
-                               'cmd', Modifiers(), 1)
-
     def testStackLengthThree(self):
         "Calling on a stack with three items (count=2) must return correctly"
         c = Calculator()
-        c.execute("'string'")
         c.execute('4')
         c.execute('5')
+        c.execute("'string'")
         string, args = c.findStringAndArgs('cmd', Modifiers(), 2)
         self.assertEqual('string', string)
         self.assertEqual([4, 5], args)
@@ -768,10 +754,10 @@ class TestFindStringAndArgs(TestCase):
     def testAllStack(self):
         "Calling on all the stack must return correctly"
         c = Calculator()
-        c.execute("'string'")
         c.execute('4')
         c.execute('5')
         c.execute('6')
+        c.execute("'string'")
         string, args = c.findStringAndArgs('cmd', strToModifiers('*'), None)
         self.assertEqual('string', string)
         self.assertEqual([4, 5, 6], args)
@@ -800,8 +786,8 @@ class TestFindStringAndArgsReversed(TestCase):
         correctly. The number of stack items is obtained from the function
         signature"""
         c = Calculator()
-        c.execute('4')
         c.execute("'string'")
+        c.execute('4')
         string, args = c.findStringAndArgs('cmd', strToModifiers('r'), None)
         self.assertEqual('string', string)
         self.assertEqual([4], args)
@@ -810,8 +796,8 @@ class TestFindStringAndArgsReversed(TestCase):
         """Calling on a stack with two items and a count must return
         correctly."""
         c = Calculator()
-        c.execute('4')
         c.execute("'string'")
+        c.execute('4')
         string, args = c.findStringAndArgs('cmd', strToModifiers('r'), 1)
         self.assertEqual('string', string)
         self.assertEqual([4], args)
@@ -819,20 +805,32 @@ class TestFindStringAndArgsReversed(TestCase):
     def testStackLengthThree(self):
         "Calling on a stack with three items (count=2) must return correctly"
         c = Calculator()
+        c.execute("'string'")
         c.execute('5')
         c.execute('4')
-        c.execute("'string'")
         string, args = c.findStringAndArgs('cmd', strToModifiers('r'), 2)
         self.assertEqual('string', string)
         self.assertEqual([5, 4], args)
 
+    def testStackLengthThreeWithCountError(self):
+        """Calling on a stack with three items and a count that points to a
+        non-string must result in an error"""
+        c = Calculator()
+        c.execute("'string'")
+        c.execute('4')
+        c.execute('5')
+        error = (r"^Cannot run 'cmd' with 1 argument. Stack item \(4\) is "
+                 r"not a string$")
+        self.assertRaisesRegex(StackError, error, c.findStringAndArgs,
+                               'cmd', strToModifiers('r'), 1)
+
     def testAllStack(self):
         "Calling on all the stack must return correctly"
         c = Calculator()
+        c.execute("'string'")
         c.execute('4')
         c.execute('5')
         c.execute('6')
-        c.execute("'string'")
         string, args = c.findStringAndArgs('cmd', strToModifiers('*r'), None)
         self.assertEqual('string', string)
         self.assertEqual([4, 5, 6], args)
@@ -844,8 +842,8 @@ class TestApply(TestCase):
     def testApplyNoCount(self):
         "apply must work correctly when not given a count"
         c = Calculator()
-        c.execute('abs :!')
         c.execute('-1')
+        c.execute('abs :!')
         c.execute('apply')
         (result,) = c.stack
         self.assertEqual(1, result)
@@ -853,8 +851,8 @@ class TestApply(TestCase):
     def testApplyWithCount(self):
         "apply must work correctly when given a count"
         c = Calculator()
-        c.execute('+ :!')
         c.execute('3 5')
+        c.execute('+ :!')
         c.execute('apply :2')
         (result,) = c.stack
         self.assertEqual(8, result)
@@ -863,9 +861,9 @@ class TestApply(TestCase):
         "apply must work correctly when Variable instances are on the stack"
         c = Calculator()
         c.execute('a=4 b=5')
-        c.execute('+ :!')
         c.execute('a :!')
         c.execute('b :!')
+        c.execute('+ :!')
         c.execute('apply')
         (result,) = c.stack
         self.assertEqual(9, result)
@@ -877,10 +875,10 @@ class TestReduce(TestCase):
     def testReduceAl(self):
         "Reduce must work correctly when told to operate on the whole stack"
         c = Calculator()
-        c.execute('+ :!')
         c.execute('5')
         c.execute('6')
         c.execute('7')
+        c.execute('+ :!')
         c.execute('reduce :*')
         (result,) = c.stack
         self.assertEqual(18, result)
@@ -888,9 +886,9 @@ class TestReduce(TestCase):
     def testReduceWithCount(self):
         "Reduce must work correctly when given a count"
         c = Calculator()
-        c.execute('+ :!')
         c.execute('5')
         c.execute('6')
+        c.execute('+ :!')
         c.execute('reduce :2')
         (result,) = c.stack
         self.assertEqual(11, result)
@@ -902,10 +900,10 @@ class TestReduceReversed(TestCase):
     def testReduceAl(self):
         "Reduce must work correctly when told to operate on the whole stack"
         c = Calculator()
+        c.execute('+ :!')
         c.execute('5')
         c.execute('6')
         c.execute('7')
-        c.execute('+ :!')
         c.execute('reduce :*r')
         (result,) = c.stack
         self.assertEqual(18, result)
@@ -914,9 +912,9 @@ class TestReduceReversed(TestCase):
         "Reduce must work correctly when given a count"
         c = Calculator()
         c.execute('4')
+        c.execute('+ :!')
         c.execute('5')
         c.execute('6')
-        c.execute('+ :!')
         c.execute('reduce :2r')
         self.assertEqual([4, 11], c.stack)
 
@@ -962,7 +960,6 @@ class TestPop(TestCase):
         c.execute('6')
         c.execute('5')
         c.execute('pop:c')
-        print(c.stack)
         (result,) = c.stack
         self.assertEqual(6, result)
 
@@ -973,16 +970,16 @@ class TestMap(TestCase):
     def testWithCount(self):
         "map must work as expected when given a count"
         c = Calculator()
-        c.execute('str :!')
         c.execute('1 2 3')
+        c.execute('str :!')
         c.execute('map :3i')
         self.assertEqual(['1', '2', '3'], c.stack)
 
     def testIterateGenerator(self):
         "The :i (iterate) modifier must work as expected on a map generator"
         c = Calculator()
-        c.execute('str :!')
         c.execute('[1,2,3]')
+        c.execute('str :!')
         c.execute('map :i')
         (result,) = c.stack
         self.assertEqual(['1', '2', '3'], result)

--- a/test/test_calculator.py
+++ b/test/test_calculator.py
@@ -119,10 +119,10 @@ class TestCalculator(TestCase):
         (result,) = c.stack
         self.assertEqual(9, result)
 
-    def testSetVariable(self):
-        "The setVariable method must have the expected effect."
+    def testSetUserVariable(self):
+        "The setUserVariable method must have the expected effect."
         c = Calculator()
-        c.setVariable('a', 5)
+        c.setUserVariable('a', 5)
         c.execute('a')
         (result,) = c.stack
         self.assertEqual(5, result)
@@ -564,6 +564,23 @@ class TestStore(TestCase):
         c.execute('"a" 4 5 6 store:r* a')
         self.assertEqual([[4, 5, 6]], c.stack)
 
+
+class TestUserVariable(TestCase):
+    "Test if variables set by the user are stored as user variables"
+
+    def testEqual(self):
+        "The syntax var=val should work"
+        c = Calculator()
+        c.execute('a=2')
+        self.assertTrue(len(c._userVariables) == 1)
+        self.assertTrue(c._variables[c._userVariables[0]] == 2)
+
+    def testStore(self):
+        "Saving a variable with the store command should work"
+        c = Calculator()
+        c.execute('2 "a" store')
+        self.assertTrue(len(c._userVariables) == 1)
+        self.assertTrue(c._variables[c._userVariables[0]] == 2)
 
 class TestFindCallableAndArgs(TestCase):
     "Test the findCallableAndArgs function"


### PR DESCRIPTION
Previously the 'variables' command showed all known variables, which
made it hard for the user to find the ones created during the session.
Make the 'variables' command instead only show the variables created by
the user, either through "var=value" or "value 'var' store" during the
current session.

Rename the old variables command to 'variables_all'.

This is being done on top of the 'reverse-reverse-8' branch in order to avoid having to change the test after that branch is merged.